### PR TITLE
mainVR in buffers

### DIFF
--- a/shadertoy/Info.plist
+++ b/shadertoy/Info.plist
@@ -32,7 +32,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>36</string>
+	<string>37</string>
 	<key>Fabric</key>
 	<dict>
 		<key>APIKey</key>

--- a/shadertoy/ShaderPassRenderer.m
+++ b/shadertoy/ShaderPassRenderer.m
@@ -93,6 +93,10 @@
 - (BOOL) createShaderProgram:(APIShaderPass *)shaderPass commonPass:(APIShaderPass *)commonPass theError:(NSString **)error {
     _shaderPass = shaderPass;
     
+    if (![shaderPass.code containsString:@"mainVR"]) {
+        _vrSettings = NULL;
+    }
+    
     NSString *VertexShaderCode;
     
     if( _vrSettings ) {


### PR DESCRIPTION
mainVR in buffers is optional. If you run the shader ‘in VR’, and the
mainVR function is not present in a buffer, mainImage will be called
instead.